### PR TITLE
Fix VoidCallback error

### DIFF
--- a/lib/src/utils/downloader_utils.dart
+++ b/lib/src/utils/downloader_utils.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:dio/dio.dart' hide ProgressCallback;
 import 'package:flowder/src/flowder.dart';


### PR DESCRIPTION
I was having an error with the VoidCallback type.

The solution was to simply import the `dart:ui` library

```
Error: Type 'VoidCallback' not found.
../…/utils/downloader_utils.dart:23
final VoidCallback onDone;
^^^^^^^^^^^^
: Error: 'VoidCallback' isn't a type.
../…/utils/downloader_utils.dart:23
final VoidCallback onDone;
^^^^^^^^^^^^
```