### PR TITLE
Fixed VoidCallback Error

### DIFF
--- a/lib/src/flowder.dart
+++ b/lib/src/flowder.dart
@@ -14,7 +14,7 @@ export 'utils/utils.dart';
 /// Global [typedef] that returns a `int` with the current byte on download
 /// and another `int` with the total of bytes of the file.
 typedef ProgressCallback = void Function(int count, int total);
-
+typedef VoidCallback = void Function();
 /// Class used as a Static Handler
 /// you can call the folowwing functions.
 /// - Flowder.download: Returns an instance of [DownloaderCore]

--- a/lib/src/utils/downloader_utils.dart
+++ b/lib/src/utils/downloader_utils.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-
+import 'dart:ui';
 import 'package:dio/dio.dart' hide ProgressCallback;
 import 'package:flowder/src/flowder.dart';
 import 'package:flowder/src/progress/interfaces/progress_interface.dart';


### PR DESCRIPTION
Fixed Errors:
Error: Type 'VoidCallback' not found.
../…/utils/downloader_utils.dart:23
final VoidCallback onDone;
^^^^^^^^^^^^
: Error: 'VoidCallback' isn't a type.
../…/utils/downloader_utils.dart:23
final VoidCallback onDone;
^^^^^^^^^^^^