### PR TITLE
Update downloader_utils.dart

### DIFF
--- a/lib/src/utils/downloader_utils.dart
+++ b/lib/src/utils/downloader_utils.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:dio/dio.dart' hide ProgressCallback;
 import 'package:flowder/src/flowder.dart';


### PR DESCRIPTION
"flutter 'VoidCallback' not found. final VoidCallback onDone" getting this error because the dart:ui package has not been introduced. Add the following code to the downloader_utils.dart file and it will run successfully.

Issue has been raised many times by users -
https://github.com/Crdzbird/flowder/issues/9